### PR TITLE
Use proper UTF-8 instead of CString.

### DIFF
--- a/crates/neon-sys/src/lib.rs
+++ b/crates/neon-sys/src/lib.rs
@@ -67,8 +67,8 @@ extern "system" {
     pub fn NeonSys_Object_GetIsolate(obj: Local) -> *mut Isolate;
     pub fn NeonSys_Object_Get_Index(out: &mut Local, object: Local, index: u32) -> bool;
     pub fn NeonSys_Object_Set_Index(out: &mut bool, object: Local, index: u32, val: Local) -> bool;
-    pub fn NeonSys_Object_Get_Bytes(out: &mut Local, object: Local, key: *const u8, len: i32) -> bool;
-    pub fn NeonSys_Object_Set_Bytes(out: &mut bool, object: Local, key: *const u8, len: i32, val: Local) -> bool;
+    pub fn NeonSys_Object_Get_String(out: &mut Local, object: Local, key: *const u8, len: i32) -> bool;
+    pub fn NeonSys_Object_Set_String(out: &mut bool, object: Local, key: *const u8, len: i32, val: Local) -> bool;
     pub fn NeonSys_Object_Get(out: &mut Local, object: Local, key: Local) -> bool;
     pub fn NeonSys_Object_Set(out: &mut bool, object: Local, key: Local, val: Local) -> bool;
 

--- a/crates/neon-sys/src/neon.cc
+++ b/crates/neon-sys/src/neon.cc
@@ -70,7 +70,7 @@ extern "C" void NeonSys_NewInteger(v8::Local<v8::Integer> *out, v8::Isolate *iso
 }
 
 extern "C" bool NeonSys_NewString(v8::Local<v8::String> *out, v8::Isolate *isolate, const uint8_t *data, int32_t len) {
-  Nan::MaybeLocal<v8::String> maybe = v8::String::NewFromOneByte(isolate, data, v8::NewStringType::kNormal, len);
+  Nan::MaybeLocal<v8::String> maybe = v8::String::NewFromUtf8(isolate, (const char*)data, v8::NewStringType::kNormal, len);
   return maybe.ToLocal(out);
 }
 
@@ -92,9 +92,9 @@ extern "C" bool NeonSys_Object_Set_Index(bool *out, v8::Local<v8::Object> object
   return maybe.IsJust() && (*out = maybe.FromJust(), true);
 }
 
-extern "C" bool NeonSys_Object_Get_Bytes(v8::Local<v8::Value> *out, v8::Local<v8::Object> obj, const uint8_t *data, int32_t len) {
+extern "C" bool NeonSys_Object_Get_String(v8::Local<v8::Value> *out, v8::Local<v8::Object> obj, const uint8_t *data, int32_t len) {
   Nan::HandleScope scope;
-  Nan::MaybeLocal<v8::String> maybe_key = v8::String::NewFromOneByte(v8::Isolate::GetCurrent(), data, v8::NewStringType::kNormal, len);
+  Nan::MaybeLocal<v8::String> maybe_key = v8::String::NewFromUtf8(v8::Isolate::GetCurrent(), (const char*)data, v8::NewStringType::kNormal, len);
   v8::Local<v8::String> key;
   if (!maybe_key.ToLocal(&key)) {
     return false;
@@ -103,10 +103,10 @@ extern "C" bool NeonSys_Object_Get_Bytes(v8::Local<v8::Value> *out, v8::Local<v8
   return maybe.ToLocal(out);
 }
 
-extern "C" bool NeonSys_Object_Set_Bytes(bool *out, v8::Local<v8::Object> obj, const uint8_t *data, int32_t len, v8::Local<v8::Value> val) {
+extern "C" bool NeonSys_Object_Set_String(bool *out, v8::Local<v8::Object> obj, const uint8_t *data, int32_t len, v8::Local<v8::Value> val) {
   // FIXME: abstract the key construction logic to avoid duplication with ^^
   Nan::HandleScope scope;
-  Nan::MaybeLocal<v8::String> maybe_key = v8::String::NewFromOneByte(v8::Isolate::GetCurrent(), data, v8::NewStringType::kNormal, len);
+  Nan::MaybeLocal<v8::String> maybe_key = v8::String::NewFromUtf8(v8::Isolate::GetCurrent(), (const char*)data, v8::NewStringType::kNormal, len);
   v8::Local<v8::String> key;
   if (!maybe_key.ToLocal(&key)) {
     return false;

--- a/crates/neon-sys/src/neon.h
+++ b/crates/neon-sys/src/neon.h
@@ -50,8 +50,8 @@ extern "C" {
   void *NeonSys_Object_GetIsolate(v8::Local<v8::Object> obj);
   bool NeonSys_Object_Get_Index(v8::Local<v8::Value> *out, v8::Local<v8::Object> object, uint32_t index);
   bool NeonSys_Object_Set_Index(bool *out, v8::Local<v8::Object> object, uint32_t index, v8::Local<v8::Value> val);
-  bool NeonSys_Object_Get_Bytes(v8::Local<v8::Value> *out, v8::Local<v8::Object> object, const uint8_t *key, int32_t len);
-  bool NeonSys_Object_Set_Bytes(bool *out, v8::Local<v8::Object> object, const uint8_t *key, int32_t len, v8::Local<v8::Value> val);
+  bool NeonSys_Object_Get_String(v8::Local<v8::Value> *out, v8::Local<v8::Object> object, const uint8_t *key, int32_t len);
+  bool NeonSys_Object_Set_String(bool *out, v8::Local<v8::Object> object, const uint8_t *key, int32_t len, v8::Local<v8::Value> val);
   bool NeonSys_Object_Get(v8::Local<v8::Value> *out, v8::Local<v8::Object> object, v8::Local<v8::Value> key);
   bool NeonSys_Object_Set(bool *out, v8::Local<v8::Object> obj, v8::Local<v8::Value> key, v8::Local<v8::Value> val);
 


### PR DESCRIPTION
Also fixes a dangling pointer bug, as `lower_str_unwrap` was returning a pointer into the `CString` allocation it had created and destroyed.

Tested on x64 Linux, Hello World works at least.