### PR TITLE
Replace unwrap with expect to warn about missing npm

### DIFF
--- a/crates/neon-sys/build.rs
+++ b/crates/neon-sys/build.rs
@@ -20,7 +20,8 @@ fn object_path(libname: &str) -> String {
 
 fn build_object_file() {
     // Ensure that all package.json dependencies and dev dependencies are installed.
-    Command::new("npm").arg("install").status().ok().unwrap();
+    Command::new("npm").arg("install").status().ok()
+        .expect(r#"failed to run "npm install" for neon-sys"#);
 
     // Run the package.json `configure` script, which invokes `node-gyp configure` from the local node_modules.
     Command::new("npm").arg("run").arg(if debug() { "configure-debug" } else { "configure-release" }).status().ok().unwrap();


### PR DESCRIPTION
When I tried to build the neon, I got this error:

```
thread '<main>' panicked at 'called `Option::unwrap()` on a `None` value', ../src/libcore/option.rs:366
```

Replaced it with friendlier alternative:

```
thread '<main>' panicked at 'failed to run "npm install" for neon-sys', ../src/libcore/option.rs:334
```